### PR TITLE
add note at end of README to clarify that gem warning should not concern students

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,4 +138,21 @@ def my_all?(collection)
 end
 ```
 
+With the above code written, you should now be passing all 5 tests (5 examples, 0 failures).
 
+#### Gem Warning
+
+
+If you are passing all your tests, you might see the following warning message:
+
+```
+WARN: Unresolved or ambigious specs during Gem::Specification.reset:
+      diff-lcs (>= 1.2.0, < 2.0)
+      Available/installed versions of this gem:
+      - 1.4.3
+      - 1.3
+WARN: Clearing out unresolved specs. Try 'gem cleanup <gem>'
+Please report a bug if this causes problems.
+```
+
+This is OK. This warning is not important at the moment and nothing is wrong with your machine. If you're passing all the tests, you can submit your lesson and move on to the next one!


### PR DESCRIPTION
since this lab does not have a gem file, running the tests can throw a gem warning with the use of 'require pry'.
the warning looks like this:

WARN: Unresolved or ambigious specs during Gem::Specification.reset:
      diff-lcs (>= 1.2.0, < 2.0)
      Available/installed versions of this gem:
      - 1.4.3
      - 1.3
WARN: Clearing out unresolved specs. Try 'gem cleanup <gem>'
Please report a bug if this causes problems.

The warning does not affect the lab or the tests. All tests can still pass successfully with the warning and the lab can be submitted, however the warning has concerned students that there's an issue with their machine. 

Added note at end of README to address this concern.